### PR TITLE
Update wayfarer-version-display.user.js

### DIFF
--- a/wayfarer-version-display.user.js
+++ b/wayfarer-version-display.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Wayfarer Version Display
-// @version      0.1.1
+// @version      0.1.2
 // @description  Displays the current Wayfarer version.
 // @namespace    https://github.com/tehstone/wayfarer-addons
 // @downloadURL  https://github.com/tehstone/wayfarer-addons/raw/main/wayfarer-version-display.user.js
@@ -55,7 +55,7 @@
             const json = JSON.parse(this.response);
             if (!json) return;
             if (json.version) {
-                box.textContent = `v${json.version.replace('release-wayfarer-web-', '')}`;
+                box.textContent = `v${json.version.replace('release-wayfarer-web-', '').split("-")[0]}`;
                 if (!version) version = json.version;
                 else if (version !== json.version) {
                     const css = `


### PR DESCRIPTION
Truncate version string displayed. Splits the string from the hyphen so the version number is displayed without the extraneous part.